### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,5 +1,7 @@
 name: tests
 
+permissions:
+  contents: read
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/SCAI-BIO/syndat/security/code-scanning/1](https://github.com/SCAI-BIO/syndat/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since this is a basic CI pipeline that only reads repository contents, the minimal required permission is `contents: read`. This block should be added at the root level of the workflow to apply to all jobs, as none of the jobs require additional permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
